### PR TITLE
[WIP]: Update betting logic to use cents token

### DIFF
--- a/canisters-client/did/individual_user_template.did
+++ b/canisters-client/did/individual_user_template.did
@@ -96,7 +96,6 @@ type DeployedCdaoCanisters = record {
 type DeveloperDistribution = record {
   developer_neurons : vec NeuronDistribution;
 };
-type DeviceIdentity = record { device_id : text; timestamp : nat64 };
 type FeedScore = record {
   current_score : nat64;
   last_synchronized_at : SystemTime;
@@ -208,12 +207,6 @@ type LinearScalingCoefficient = record {
   slope_denominator : opt nat64;
   to_direct_participation_icp_e8s : opt nat64;
 };
-type MLFeedCacheItem = record {
-  post_id : nat64;
-  canister_id : principal;
-  video_id : text;
-  creator_principal_id : opt principal;
-};
 type MigrationErrors = variant {
   InvalidToCanister;
   InvalidFromCanister;
@@ -234,6 +227,7 @@ type MigrationInfo = variant {
   MigratedToYral : record { account_principal : principal };
 };
 type MintEvent = variant {
+  Airdrop : record { amount : nat64 };
   NewUserSignup : record { new_user_principal_id : principal };
   Referral : record {
     referrer_user_principal_id : principal;
@@ -367,6 +361,13 @@ type PostViewStatistics = record {
   threshold_view_count : nat64;
 };
 type Principals = record { principals : vec principal };
+type PumpDumpOutcomePayoutEvent = variant {
+  CreatorRewardFromPumpDumpGame;
+  RewardFromPumpDumpGame : record {
+    game_direction : GameDirection;
+    token_root_canister_id : principal;
+  };
+};
 type PumpNDumpStateDiff = variant {
   Participant : ParticipatedGameInfo;
   CreatorReward : nat;
@@ -381,49 +382,48 @@ type RejectionCode = variant {
   SysFatal;
   CanisterReject;
 };
-type Result = variant { Ok : bool; Err : text };
-type Result_1 = variant { Ok; Err : text };
-type Result_10 = variant { Ok : BetDetails; Err : text };
-type Result_11 = variant { Ok : Post; Err };
-type Result_12 = variant { Ok : SystemTime; Err : text };
-type Result_13 = variant {
+type Result = variant { Ok; Err : text };
+type Result_1 = variant { Ok : nat64; Err : text };
+type Result_10 = variant { Ok : Post; Err };
+type Result_11 = variant { Ok : SystemTime; Err : text };
+type Result_12 = variant {
   Ok : vec PostDetailsForFrontend;
   Err : GetPostsOfUserProfileError;
 };
-type Result_14 = variant { Ok : SessionType; Err : text };
-type Result_15 = variant { Ok : vec SuccessHistoryItemV1; Err : text };
-type Result_16 = variant { Ok : vec principal; Err : PaginationError };
-type Result_17 = variant {
+type Result_13 = variant { Ok : SessionType; Err : text };
+type Result_14 = variant { Ok : vec SuccessHistoryItemV1; Err : text };
+type Result_15 = variant { Ok : vec principal; Err : PaginationError };
+type Result_16 = variant {
   Ok : vec record { nat64; TokenEvent };
   Err : PaginationError;
 };
-type Result_18 = variant { Ok : vec WatchHistoryItem; Err : text };
-type Result_19 = variant { Ok : vec text; Err : NamespaceErrors };
-type Result_2 = variant { Ok : nat64; Err : text };
-type Result_20 = variant { Ok : vec record { nat64; nat8 }; Err : text };
-type Result_21 = variant { Ok : vec ParticipatedGameInfo; Err : text };
-type Result_22 = variant { Ok; Err : MigrationErrors };
-type Result_23 = variant { Ok; Err : AirdropError };
-type Result_24 = variant { Ok : text; Err : text };
-type Result_25 = variant { Ok : IndividualUserCreatorDaoEntry; Err : text };
-type Result_26 = variant { Committed : Committed; Aborted : record {} };
-type Result_27 = variant { Ok : Ok; Err : GovernanceError };
-type Result_28 = variant { Ok; Err : CdaoTokenError };
-type Result_29 = variant {
+type Result_17 = variant { Ok : vec WatchHistoryItem; Err : text };
+type Result_18 = variant { Ok : vec text; Err : NamespaceErrors };
+type Result_19 = variant { Ok : vec record { nat64; nat8 }; Err : text };
+type Result_2 = variant { Ok : bool; Err : CdaoTokenError };
+type Result_20 = variant { Ok : vec ParticipatedGameInfo; Err : text };
+type Result_21 = variant { Ok; Err : MigrationErrors };
+type Result_22 = variant { Ok; Err : AirdropError };
+type Result_23 = variant { Ok : IndividualUserCreatorDaoEntry; Err : text };
+type Result_24 = variant { Committed : Committed; Aborted : record {} };
+type Result_25 = variant { Ok : Ok; Err : GovernanceError };
+type Result_26 = variant { Ok; Err : CdaoTokenError };
+type Result_27 = variant { Ok : text; Err : text };
+type Result_28 = variant {
   Ok : UserProfileDetailsForFrontend;
   Err : UpdateProfileDetailsError;
 };
-type Result_3 = variant { Ok : bool; Err : CdaoTokenError };
-type Result_30 = variant { Ok; Err : UpdateProfileSetUniqueUsernameError };
-type Result_4 = variant {
+type Result_29 = variant { Ok; Err : UpdateProfileSetUniqueUsernameError };
+type Result_3 = variant {
   Ok : BettingStatus;
   Err : BetOnCurrentlyViewingPostError;
 };
-type Result_5 = variant { Ok : NamespaceForFrontend; Err : NamespaceErrors };
-type Result_6 = variant { Ok : opt text; Err : NamespaceErrors };
-type Result_7 = variant { Ok; Err : NamespaceErrors };
-type Result_8 = variant { Ok : DeployedCdaoCanisters; Err : CdaoDeployError };
-type Result_9 = variant { Ok : bool; Err : FollowAnotherUserProfileError };
+type Result_4 = variant { Ok : NamespaceForFrontend; Err : NamespaceErrors };
+type Result_5 = variant { Ok : opt text; Err : NamespaceErrors };
+type Result_6 = variant { Ok; Err : NamespaceErrors };
+type Result_7 = variant { Ok : DeployedCdaoCanisters; Err : CdaoDeployError };
+type Result_8 = variant { Ok : bool; Err : FollowAnotherUserProfileError };
+type Result_9 = variant { Ok : BetDetails; Err : text };
 type RoomBetPossibleOutcomes = variant { HotWon; BetOngoing; Draw; NotWon };
 type RoomDetails = record {
   total_hot_bets : nat64;
@@ -434,10 +434,10 @@ type RoomDetails = record {
 };
 type SessionType = variant { AnonymousSession; RegisteredSession };
 type SettleNeuronsFundParticipationRequest = record {
-  result : opt Result_26;
+  result : opt Result_24;
   nns_proposal_id : opt nat64;
 };
-type SettleNeuronsFundParticipationResponse = record { result : opt Result_27 };
+type SettleNeuronsFundParticipationResponse = record { result : opt Result_25 };
 type SlotDetails = record { room_details : vec record { nat64; RoomDetails } };
 type SnsInitPayload = record {
   url : opt text;
@@ -479,7 +479,15 @@ type SnsInitPayload = record {
   min_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
-type StakeEvent = variant { BetOnHotOrNotPost : PlaceBetArg };
+type StakeEvent = variant {
+  BetOnHotOrNotPost : PlaceBetArg;
+  BetOnPumpDump : record {
+    root_canister_id : principal;
+    pumps : nat64;
+    dumps : nat64;
+  };
+  BetFailureRefund : PlaceBetArg;
+};
 type SuccessHistoryItemV1 = record {
   post_id : nat64;
   percentage_watched : float32;
@@ -497,6 +505,7 @@ type SystemTime = record {
   secs_since_epoch : nat64;
 };
 type TokenEvent = variant {
+  Withdraw : record { amount : nat; event_type : WithdrawEvent };
   Stake : record {
     timestamp : SystemTime;
     details : StakeEvent;
@@ -504,6 +513,10 @@ type TokenEvent = variant {
   };
   Burn;
   Mint : record { timestamp : SystemTime; details : MintEvent; amount : nat64 };
+  PumpDumpOutcomePayout : record {
+    payout_type : PumpDumpOutcomePayoutEvent;
+    amount : nat;
+  };
   Transfer : record {
     to_account : principal;
     timestamp : SystemTime;
@@ -581,136 +594,143 @@ type WatchHistoryItem = record {
   publisher_canister_id : principal;
   cf_video_id : text;
 };
+type WithdrawEvent = variant { WithdrawRequest; WithdrawRequestFailed };
 service : (IndividualUserTemplateInitArgs) -> {
-  add_device_id : (text) -> (Result);
-  add_dollr_to_liquidity_pool : (principal, nat) -> (Result_1);
-  add_post_v2 : (PostDetailsFromFrontend) -> (Result_2);
-  add_token : (principal) -> (Result_3);
-  bet_on_currently_viewing_post : (PlaceBetArg) -> (Result_4);
-  check_and_update_scores_and_share_with_post_cache_if_difference_beyond_threshold : (
-    vec nat64
-  ) -> ();
+  add_dollr_to_liquidity_pool : (principal, nat) -> (Result);
+  add_post_v2 : (PostDetailsFromFrontend) -> (Result_1);
+  add_token : (principal) -> (Result_2);
+  bet_on_currently_viewing_post : (PlaceBetArg) -> (Result_3);
+  bet_on_currently_viewing_post_v1 : (PlaceBetArg) -> (Result_3);
   clear_snapshot : () -> ();
-  create_a_namespace : (text) -> (Result_5);
+  create_a_namespace : (text) -> (Result_4);
   delete_all_creator_token : () -> ();
-  delete_key_value_pair : (nat64, text) -> (Result_6);
-  delete_multiple_key_value_pairs : (nat64, vec text) -> (Result_7);
-  delete_post : (nat64) -> (Result_1);
-  deploy_cdao_sns : (SnsInitPayload, nat64) -> (Result_8);
+  delete_key_value_pair : (nat64, text) -> (Result_5);
+  delete_multiple_key_value_pairs : (nat64, vec text) -> (Result_6);
+  delete_post : (nat64) -> (Result);
+  deploy_cdao_sns : (SnsInitPayload, nat64) -> (Result_7);
   deployed_cdao_canisters : () -> (vec DeployedCdaoCanisters) query;
-  do_i_follow_this_user : (FolloweeArg) -> (Result_9) query;
+  do_i_follow_this_user : (FolloweeArg) -> (Result_8) query;
   download_snapshot : (nat64, nat64) -> (blob) query;
-  get_bet_details_for_a_user_on_a_post : (principal, nat64) -> (
-    Result_10
-  ) query;
-  get_device_identities : () -> (vec DeviceIdentity) query;
-  get_entire_individual_post_detail_by_id : (nat64) -> (Result_11) query;
+  get_bet_details_for_a_user_on_a_post : (principal, nat64) -> (Result_9) query;
+  get_bet_details_for_a_user_on_a_post_v1 : (principal, nat64) -> (
+      Result_9,
+    ) query;
+  get_entire_individual_post_detail_by_id : (nat64) -> (Result_10) query;
   get_hot_or_not_bet_details_for_this_post : (nat64) -> (BettingStatus) query;
+  get_hot_or_not_bet_details_for_this_post_v1 : (nat64) -> (
+      BettingStatus,
+    ) query;
   get_hot_or_not_bets_placed_by_this_profile_with_pagination : (nat64) -> (
-    vec PlacedBetDetail
-  ) query;
+      vec PlacedBetDetail,
+    ) query;
+  get_hot_or_not_bets_placed_by_this_profile_with_pagination_v1 : (nat64) -> (
+      vec PlacedBetDetail,
+    ) query;
   get_individual_hot_or_not_bet_placed_by_this_profile : (principal, nat64) -> (
-    opt PlacedBetDetail
-  ) query;
+      opt PlacedBetDetail,
+    ) query;
+  get_individual_hot_or_not_bet_placed_by_this_profile_v1 : (
+      principal,
+      nat64,
+    ) -> (opt PlacedBetDetail) query;
   get_individual_post_details_by_id : (nat64) -> (PostDetailsForFrontend) query;
-  get_last_access_time : () -> (Result_12) query;
-  get_last_canister_functionality_access_time : () -> (Result_12) query;
-  get_ml_feed_cache_paginated : (nat64, nat64) -> (vec MLFeedCacheItem) query;
-  get_posts_of_this_user_profile_with_pagination : (nat64, nat64) -> (
-    Result_13
-  ) query;
+  get_last_access_time : () -> (Result_11) query;
+  get_last_canister_functionality_access_time : () -> (Result_11) query;
   get_posts_of_this_user_profile_with_pagination_cursor : (nat64, nat64) -> (
-    Result_13
-  ) query;
+      Result_12,
+    ) query;
   get_principals_that_follow_this_profile_paginated : (opt nat64) -> (
-    vec record { nat64; FollowEntryDetail }
-  ) query;
+      vec record { nat64; FollowEntryDetail },
+    ) query;
   get_principals_this_profile_follows_paginated : (opt nat64) -> (
-    vec record { nat64; FollowEntryDetail }
-  ) query;
+      vec record { nat64; FollowEntryDetail },
+    ) query;
   get_profile_details : () -> (UserProfileDetailsForFrontend) query;
   get_profile_details_v2 : () -> (UserProfileDetailsForFrontendV2) query;
   get_rewarded_for_referral : (principal, principal) -> ();
   get_rewarded_for_signing_up : () -> ();
-  get_session_type : () -> (Result_14) query;
+  get_session_type : () -> (Result_13) query;
   get_stable_memory_size : () -> (nat64) query;
-  get_success_history : () -> (Result_15) query;
+  get_success_history : () -> (Result_14) query;
   get_token_roots_of_this_user_with_pagination_cursor : (nat64, nat64) -> (
-    Result_16
-  ) query;
+      Result_15,
+    ) query;
   get_user_caniser_cycle_balance : () -> (nat) query;
-  get_user_propensity : () -> (float64) query;
   get_user_utility_token_transaction_history_with_pagination : (
-    nat64,
-    nat64,
-  ) -> (Result_17) query;
+      nat64,
+      nat64,
+    ) -> (Result_16) query;
   get_utility_token_balance : () -> (nat64) query;
   get_version : () -> (text) query;
   get_version_number : () -> (nat64) query;
-  get_watch_history : () -> (Result_18) query;
+  get_watch_history : () -> (Result_17) query;
   get_well_known_principal_value : (KnownPrincipalType) -> (
-    opt principal
-  ) query;
+      opt principal,
+    ) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
-  list_namespace_keys : (nat64) -> (Result_19) query;
+  list_namespace_keys : (nat64) -> (Result_18) query;
   list_namespaces : (nat64, nat64) -> (vec NamespaceForFrontend) query;
   load_snapshot : () -> ();
   net_earnings : () -> (nat) query;
-  once_reenqueue_timers_for_pending_bet_outcomes : () -> (Result_20);
+  once_reenqueue_timers_for_pending_bet_outcomes : () -> (Result_19);
   pd_balance_info : () -> (BalanceInfo) query;
   played_game_count : () -> (nat64) query;
-  played_game_info_with_pagination_cursor : (nat64, nat64) -> (Result_21) query;
+  played_game_info_with_pagination_cursor : (nat64, nat64) -> (Result_20) query;
   pumps_and_dumps : () -> (PumpsAndDumps) query;
-  read_key_value_pair : (nat64, text) -> (Result_6) query;
+  read_key_value_pair : (nat64, text) -> (Result_5) query;
   receive_and_save_snaphot : (nat64, blob) -> ();
-  receive_bet_from_bet_makers_canister : (PlaceBetArg, principal) -> (Result_4);
+  receive_bet_from_bet_makers_canister : (PlaceBetArg, principal) -> (Result_3);
+  receive_bet_from_bet_makers_canister_v1 : (PlaceBetArg, principal) -> (
+      Result_3,
+    );
   receive_bet_winnings_when_distributed : (nat64, BetOutcomeForBetMaker) -> ();
-  receive_data_from_hotornot : (principal, nat64, vec Post) -> (Result_22);
-  reconcile_user_state : (vec PumpNDumpStateDiff) -> (Result_1);
-  redeem_gdollr : (nat) -> (Result_1);
-  request_airdrop : (principal, opt blob, nat, principal) -> (Result_23);
-  reset_ml_feed_cache : () -> (Result_24);
+  receive_bet_winnings_when_distributed_v1 : (
+      nat64,
+      BetOutcomeForBetMaker,
+    ) -> ();
+  receive_data_from_hotornot : (principal, nat64, vec Post) -> (Result_21);
+  reconcile_user_state : (vec PumpNDumpStateDiff) -> (Result);
+  redeem_gdollr : (nat) -> (Result);
+  request_airdrop : (principal, opt blob, nat, principal) -> (Result_22);
   return_cycles_to_user_index_canister : (opt nat) -> ();
   save_snapshot_json : () -> (nat32);
-  send_creator_dao_stats_to_subnet_orchestrator : () -> (Result_25);
+  send_creator_dao_stats_to_subnet_orchestrator : () -> (Result_23);
   set_controller_as_subnet_orchestrator : (principal) -> ();
   settle_neurons_fund_participation : (
-    SettleNeuronsFundParticipationRequest
-  ) -> (SettleNeuronsFundParticipationResponse);
-  stake_dollr_for_gdollr : (nat) -> (Result_1);
+      SettleNeuronsFundParticipationRequest,
+    ) -> (SettleNeuronsFundParticipationResponse);
+  stake_dollr_for_gdollr : (nat) -> (Result);
   transfer_token_to_user_canister : (principal, principal, opt blob, nat) -> (
-    Result_28
-  );
-  transfer_tokens_and_posts : (principal, principal) -> (Result_22);
-  update_last_access_time : () -> (Result_24);
+      Result_26,
+    );
+  transfer_tokens_and_posts : (principal, principal) -> (Result_21);
+  update_last_access_time : () -> (Result_27);
   update_last_canister_functionality_access_time : () -> ();
-  update_ml_feed_cache : (vec MLFeedCacheItem) -> (Result_24);
-  update_pd_onboarding_reward : (nat) -> (Result_1);
+  update_pd_onboarding_reward : (nat) -> (Result);
   update_post_add_view_details : (nat64, PostViewDetailsFromFrontend) -> ();
   update_post_as_ready_to_view : (nat64) -> ();
   update_post_increment_share_count : (nat64) -> (nat64);
   update_post_status : (nat64, PostStatus) -> ();
   update_post_toggle_like_status_by_caller : (nat64) -> (bool);
   update_profile_display_details : (UserProfileUpdateDetailsFromFrontend) -> (
-    Result_29
-  );
-  update_profile_owner : (opt principal) -> (Result_1);
-  update_profile_set_unique_username_once : (text) -> (Result_30);
+      Result_28,
+    );
+  update_profile_owner : (opt principal) -> (Result);
+  update_profile_set_unique_username_once : (text) -> (Result_29);
   update_profiles_i_follow_toggle_list_with_specified_profile : (
-    FolloweeArg
-  ) -> (Result_9);
+      FolloweeArg,
+    ) -> (Result_8);
   update_profiles_that_follow_me_toggle_list_with_specified_profile : (
-    FollowerArg
-  ) -> (Result_9);
-  update_referrer_details : (UserCanisterDetails) -> (Result_24);
-  update_session_type : (SessionType) -> (Result_24);
-  update_success_history : (SuccessHistoryItemV1) -> (Result_24);
-  update_user_propensity : (float64) -> (Result_24);
-  update_watch_history : (WatchHistoryItem) -> (Result_24);
+      FollowerArg,
+    ) -> (Result_8);
+  update_referrer_details : (UserCanisterDetails) -> (Result_27);
+  update_session_type : (SessionType) -> (Result_27);
+  update_success_history : (SuccessHistoryItemV1) -> (Result_27);
+  update_watch_history : (WatchHistoryItem) -> (Result_27);
   update_well_known_principal : (KnownPrincipalType, principal) -> ();
-  upgrade_creator_dao_governance_canisters : (blob) -> (Result_1);
-  write_key_value_pair : (nat64, text, text) -> (Result_6);
+  upgrade_creator_dao_governance_canisters : (blob) -> (Result);
+  write_key_value_pair : (nat64, text, text) -> (Result_5);
   write_multiple_key_value_pairs : (nat64, vec record { text; text }) -> (
-    Result_7
-  );
-};
+      Result_6,
+    );
+}

--- a/canisters-common/src/cursored_data/ref_history.rs
+++ b/canisters-common/src/cursored_data/ref_history.rs
@@ -4,7 +4,7 @@ use ic_agent::AgentError;
 use crate::Canisters;
 
 use super::{CursoredDataProvider, KeyedData, PageEntry};
-use canisters_client::individual_user_template::{MintEvent, Result17, TokenEvent};
+use canisters_client::individual_user_template::{MintEvent, Result16, TokenEvent};
 
 #[derive(Clone, Copy)]
 pub struct HistoryDetails {
@@ -38,8 +38,8 @@ impl CursoredDataProvider for ReferralHistory {
             .get_user_utility_token_transaction_history_with_pagination(from as u64, end as u64)
             .await?;
         let history = match history {
-            Result17::Ok(history) => history,
-            Result17::Err(_) => {
+            Result16::Ok(history) => history,
+            Result16::Err(_) => {
                 log::warn!("failed to get posts");
                 return Ok(PageEntry {
                     data: vec![],
@@ -50,7 +50,7 @@ impl CursoredDataProvider for ReferralHistory {
         let list_end = history.len() < (end - from);
         let details = history
             .into_iter()
-            .filter_map(|(_, ev)| {
+            .filter_map(|ev| {
                 let TokenEvent::Mint {
                     timestamp,
                     details:
@@ -59,7 +59,7 @@ impl CursoredDataProvider for ReferralHistory {
                             ..
                         },
                     amount,
-                } = ev
+                } = ev.1
                 else {
                     return None;
                 };

--- a/canisters-common/src/cursored_data/token_roots.rs
+++ b/canisters-common/src/cursored_data/token_roots.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use candid::Principal;
-use canisters_client::individual_user_template::Result16;
+use canisters_client::individual_user_template::Result15;
 use futures_util::{
     future,
     stream::{self, FuturesOrdered, FuturesUnordered},
@@ -112,7 +112,7 @@ impl<
 
         let mut tokens_fetched = 0;
         let mut tokens: Vec<TokenListResponse> = match tokens {
-            Result16::Ok(v) => {
+            Result15::Ok(v) => {
                 tokens_fetched = v.len();
                 v.into_iter()
                     .map(|t| async move {
@@ -151,7 +151,7 @@ impl<
                     .collect::<Vec<TokenListResponse>>()
                     .await
             }
-            Result16::Err(_) => vec![],
+            Result15::Err(_) => vec![],
         };
 
         println!("{tokens_fetched}, {}, {}", end - start, tokens.len());

--- a/canisters-common/src/lib.rs
+++ b/canisters-common/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use agent_wrapper::AgentWrapper;
 use candid::{Decode, Principal};
 use canisters_client::{
-    individual_user_template::{IndividualUserTemplate, Result24, Result8, UserCanisterDetails},
+    individual_user_template::{IndividualUserTemplate, Result27, Result8, UserCanisterDetails},
     platform_orchestrator::PlatformOrchestrator,
     post_cache::PostCache,
     sns_governance::SnsGovernance,
@@ -194,8 +194,8 @@ impl Canisters<true> {
             .await
             .map_err(|e| e.to_string())
         {
-            Ok(Result24::Ok(_)) => (),
-            Err(e) | Ok(Result24::Err(e)) => log::warn!("Failed to update last access time: {}", e),
+            Ok(Result27::Ok(_)) => (),
+            Err(e) | Ok(Result27::Err(e)) => log::warn!("Failed to update last access time: {}", e),
         }
 
         res.profile_details = Some(user.get_profile_details().await?.into());

--- a/canisters-common/src/utils/vote.rs
+++ b/canisters-common/src/utils/vote.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use canisters_client::individual_user_template::{
-    BetDirection, BetOutcomeForBetMaker, BettingStatus, PlaceBetArg, PlacedBetDetail, Result4,
+    BetDirection, BetOutcomeForBetMaker, BettingStatus, PlaceBetArg, PlacedBetDetail, Result3,
 };
 use serde::{Deserialize, Serialize};
 use web_time::Duration;
@@ -115,8 +115,8 @@ impl Canisters<true> {
         let res = user.bet_on_currently_viewing_post(place_bet_arg).await?;
 
         let betting_status = match res {
-            Result4::Ok(p) => p,
-            Result4::Err(e) => {
+            Result3::Ok(p) => p,
+            Result3::Err(e) => {
                 // todo send event that betting failed
                 return Err(Error::YralCanister(format!(
                     "bet_on_currently_viewing_post error {e:?}"

--- a/ml-feed-cache/src/lib.rs
+++ b/ml-feed-cache/src/lib.rs
@@ -4,8 +4,8 @@ use consts::{
     MAX_GLOBAL_CACHE_LEN, MAX_SUCCESS_HISTORY_CACHE_LEN, MAX_USER_CACHE_LEN,
     MAX_WATCH_HISTORY_CACHE_LEN,
 };
-use redis::{AsyncCommands, Commands};
-use types::{MLFeedCacheHistoryItem, PostItem, get_history_item_score};
+use redis::AsyncCommands;
+use types::{get_history_item_score, MLFeedCacheHistoryItem, PostItem};
 
 pub mod consts;
 pub mod types;


### PR DESCRIPTION
The betting for the posts on yral is now being changed to use the cents token.

Since the cents token is also being used in PumpNDump, we need to ensure they are synced up properly. For this, they will now make requests to cloudflare which will in turn put the bets for the users in the canisters.

### Current Proposed Changes

```mermaid
sequenceDiagram
  Frontend ->> Cloudflare: calls cloudflare with place bet arg (should be an authenticated call.)
   Cloudflare ->> Canister A: Place bet on currently viewing post v1 (sync the games before that.)
   Canister A -->> Canister B: Receive bet from bet maker canister

```