### PR TITLE
feat: add LTX-2 video generation model

### DIFF
--- a/canisters-common/src/utils/posts.rs
+++ b/canisters-common/src/utils/posts.rs
@@ -213,7 +213,9 @@ impl PostDetails {
 impl<const A: bool> Canisters<A> {
     #[instrument(skip(self))]
     async fn fetch_nsfw_probability(&self, video_uid: &str) -> Result<f32> {
-        let url = format!("https://offchain.yral.com/api/v2/posts/nsfw_prob/{video_uid}");
+        let url = format!(
+            "https://pr-399-dolr-ai-off-chain-agent.fly.dev/api/v2/posts/nsfw_prob/{video_uid}"
+        );
 
         let response = reqwest::get(&url).await?;
 

--- a/canisters-common/src/utils/posts.rs
+++ b/canisters-common/src/utils/posts.rs
@@ -214,7 +214,7 @@ impl<const A: bool> Canisters<A> {
     #[instrument(skip(self))]
     async fn fetch_nsfw_probability(&self, video_uid: &str) -> Result<f32> {
         let url = format!(
-            "https://pr-399-dolr-ai-off-chain-agent.fly.dev/api/v2/posts/nsfw_prob/{video_uid}"
+            "https://offchain.yral.com/api/v2/posts/nsfw_prob/{video_uid}"
         );
 
         let response = reqwest::get(&url).await?;

--- a/global-constants/src/lib.rs
+++ b/global-constants/src/lib.rs
@@ -97,7 +97,7 @@ pub const WAN2_5_FAST_COST_USD_CENTS: u64 = 50; // $0.5
 pub const SEEDANCE_COST_USD_CENTS: u64 = 50; // $0.5
 pub const TALKINGHEAD_COST_USD_CENTS: u64 = 50; // $0.5
 pub const INTTEST_COST_USD_CENTS: u64 = 0; // Free for testing
-pub const LTX2_COST_USD_CENTS: u64 = 25; // $0.25 - Self-hosted LTX-2 on Vast.ai H100
+pub const LTX2_COST_USD_CENTS: u64 = 0; // Free - Self-hosted LTX-2 on Vast.ai H100
 
 // Token conversion ratios for video generation
 // Based on: $0.5 (50 cents) = 500 sats = 100 dolr

--- a/global-constants/src/lib.rs
+++ b/global-constants/src/lib.rs
@@ -97,6 +97,7 @@ pub const WAN2_5_FAST_COST_USD_CENTS: u64 = 50; // $0.5
 pub const SEEDANCE_COST_USD_CENTS: u64 = 50; // $0.5
 pub const TALKINGHEAD_COST_USD_CENTS: u64 = 50; // $0.5
 pub const INTTEST_COST_USD_CENTS: u64 = 0; // Free for testing
+pub const LTX2_COST_USD_CENTS: u64 = 25; // $0.25 - Self-hosted LTX-2 on Vast.ai H100
 
 // Token conversion ratios for video generation
 // Based on: $0.5 (50 cents) = 500 sats = 100 dolr

--- a/videogen-common/src/adapter_registry.rs
+++ b/videogen-common/src/adapter_registry.rs
@@ -36,10 +36,10 @@ impl AdapterRegistry {
     /// Get provider information for all registered models
     pub fn get_all_providers(&self) -> ProvidersResponse {
         let providers = vec![
-            Wan25FastModel::get_provider_info(), // Default
+            Ltx2Model::get_provider_info(), // Default
+            Wan25FastModel::get_provider_info(),
             Wan25Model::get_provider_info(),
             LumaLabsModel::get_provider_info(),
-            Ltx2Model::get_provider_info(),
             IntTestModel::get_provider_info(),
             SpeechToVideoModel::get_provider_info(),
         ];
@@ -53,9 +53,9 @@ impl AdapterRegistry {
     /// Get provider information for all prod models
     pub fn get_all_prod_providers(&self) -> ProvidersResponse {
         let providers = vec![
-            Wan25FastModel::get_provider_info(), // Default
+            Ltx2Model::get_provider_info(), // Default
+            Wan25FastModel::get_provider_info(),
             Wan25Model::get_provider_info(),
-            Ltx2Model::get_provider_info(),
         ];
 
         ProvidersResponse {

--- a/videogen-common/src/adapter_registry.rs
+++ b/videogen-common/src/adapter_registry.rs
@@ -2,7 +2,9 @@
 use std::sync::LazyLock;
 
 use crate::models::speech_to_video::SpeechToVideoModel;
-use crate::models::{IntTestModel, LumaLabsModel, TalkingHeadModel, Wan25FastModel, Wan25Model};
+use crate::models::{
+    IntTestModel, Ltx2Model, LumaLabsModel, TalkingHeadModel, Wan25FastModel, Wan25Model,
+};
 use crate::types::VideoGenError;
 use crate::types_v2::{ProviderInfo, ProvidersResponse, VideoGenRequestV2};
 use crate::VideoGenInput;
@@ -23,6 +25,7 @@ impl AdapterRegistry {
             "wan2_5" => Wan25Model::from_unified_request(request),
             "wan2_5_fast" => Wan25FastModel::from_unified_request(request),
             "speech_to_video" => SpeechToVideoModel::from_unified_request(request),
+            "ltx2" => Ltx2Model::from_unified_request(request),
             _ => Err(VideoGenError::InvalidInput(format!(
                 "Unknown model: {}",
                 request.model_id
@@ -36,6 +39,7 @@ impl AdapterRegistry {
             Wan25FastModel::get_provider_info(), // Default
             Wan25Model::get_provider_info(),
             LumaLabsModel::get_provider_info(),
+            Ltx2Model::get_provider_info(),
             IntTestModel::get_provider_info(),
             SpeechToVideoModel::get_provider_info(),
         ];
@@ -52,6 +56,7 @@ impl AdapterRegistry {
             Wan25FastModel::get_provider_info(), // Default
             Wan25Model::get_provider_info(),
             LumaLabsModel::get_provider_info(),
+            Ltx2Model::get_provider_info(),
         ];
 
         ProvidersResponse {
@@ -69,6 +74,7 @@ impl AdapterRegistry {
             "wan2_5" => Some(Wan25Model::get_provider_info()),
             "wan2_5_fast" => Some(Wan25FastModel::get_provider_info()),
             "speech_to_video" => Some(SpeechToVideoModel::get_provider_info()),
+            "ltx2" => Some(Ltx2Model::get_provider_info()),
             _ => None,
         }
     }

--- a/videogen-common/src/models/ltx2.rs
+++ b/videogen-common/src/models/ltx2.rs
@@ -123,7 +123,7 @@ impl Ltx2Model {
             cost: CostInfo::from_usd_cents(LTX2_COST_USD_CENTS),
             supports_image: true,
             supports_negative_prompt: false, // Hardcoded
-            supports_audio: false, // Audio output is very weak
+            supports_audio: true,
             supports_audio_input: false,
             supports_seed: false,
             allowed_aspect_ratios: vec![AspectRatioV2::Ratio16x9, AspectRatioV2::Ratio9x16],

--- a/videogen-common/src/models/ltx2.rs
+++ b/videogen-common/src/models/ltx2.rs
@@ -1,0 +1,147 @@
+use crate::generator::FlowControlFromEnv;
+use crate::types::{ImageData, VideoGenProvider, VideoGenerator};
+use crate::{VideoGenError, VideoGenInput};
+use candid::CandidType;
+use global_constants::LTX2_COST_USD_CENTS;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// LTX-2 19B Distilled model - Self-hosted on Vast.ai H100
+/// Supports text-to-video, image-to-video, and image+text-to-video
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, CandidType)]
+pub struct Ltx2Model {
+    pub prompt: String,
+    pub image: Option<ImageData>,
+}
+
+impl VideoGenerator for Ltx2Model {
+    fn model_id(&self) -> &'static str {
+        "ltx2"
+    }
+
+    fn provider(&self) -> VideoGenProvider {
+        VideoGenProvider::Ltx2
+    }
+
+    fn validate_input(&self) -> Result<(), VideoGenError> {
+        // At least one of prompt or image must be provided
+        if self.prompt.is_empty() && self.image.is_none() {
+            return Err(VideoGenError::InvalidInput(
+                "Either prompt or image must be provided".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn get_prompt(&self) -> &str {
+        &self.prompt
+    }
+
+    fn get_image(&self) -> Option<&ImageData> {
+        self.image.as_ref()
+    }
+
+    fn get_image_mut(&mut self) -> Option<&mut ImageData> {
+        self.image.as_mut()
+    }
+
+    fn flow_control_config(&self) -> Option<(u32, u32)> {
+        None // Will be configured via env vars
+    }
+
+    fn supports_webhook_callbacks(&self) -> bool {
+        true
+    }
+}
+
+impl FlowControlFromEnv for Ltx2Model {
+    fn env_prefix(&self) -> &'static str {
+        "LTX2"
+    }
+}
+
+impl Ltx2Model {
+    /// Create from unified v2 request
+    pub fn from_unified_request(
+        unified: crate::types_v2::VideoGenRequestV2,
+    ) -> Result<VideoGenInput, VideoGenError> {
+        use crate::types_v2::ResolutionV2;
+
+        // Validate parameters
+        if unified.negative_prompt.is_some() {
+            return Err(VideoGenError::InvalidInput(
+                "LTX-2 negative prompt is hardcoded and cannot be customized".to_string(),
+            ));
+        }
+
+        if unified.seed.is_some() {
+            return Err(VideoGenError::InvalidInput(
+                "LTX-2 seed is not configurable".to_string(),
+            ));
+        }
+
+        // Validate duration (only 5s supported - 121 frames at 24fps)
+        if let Some(duration) = unified.duration_seconds {
+            if duration != 5 {
+                return Err(VideoGenError::InvalidInput(
+                    "LTX-2 only supports 5 second duration".to_string(),
+                ));
+            }
+        }
+
+        // Validate resolution (720p or 1080p supported)
+        if let Some(ref res) = unified.resolution {
+            if *res != ResolutionV2::R720p && *res != ResolutionV2::R1080p {
+                return Err(VideoGenError::InvalidInput(
+                    "LTX-2 supports 720p and 1080p resolutions".to_string(),
+                ));
+            }
+        }
+
+        // At least prompt or image must be provided
+        if unified.prompt.is_empty() && unified.image.is_none() {
+            return Err(VideoGenError::InvalidInput(
+                "Either prompt or image must be provided".to_string(),
+            ));
+        }
+
+        Ok(VideoGenInput::Ltx2(Ltx2Model {
+            prompt: unified.prompt,
+            image: unified.image,
+        }))
+    }
+
+    /// Get provider information for v2 API
+    pub fn get_provider_info() -> crate::types_v2::ProviderInfo {
+        use crate::types_v2::{AspectRatioV2, CostInfo, ResolutionV2};
+        use std::collections::HashMap;
+
+        crate::types_v2::ProviderInfo {
+            id: "ltx2".to_string(),
+            name: "LTX-2 Video".to_string(),
+            description: "Lightricks LTX-2 19B distilled model for fast, high-quality video generation. Supports text-to-video and image-to-video.".to_string(),
+            cost: CostInfo::from_usd_cents(LTX2_COST_USD_CENTS),
+            supports_image: true,
+            supports_negative_prompt: false, // Hardcoded
+            supports_audio: false, // Audio output is very weak
+            supports_audio_input: false,
+            supports_seed: false,
+            allowed_aspect_ratios: vec![AspectRatioV2::Ratio16x9, AspectRatioV2::Ratio9x16],
+            allowed_resolutions: vec![ResolutionV2::R720p, ResolutionV2::R1080p],
+            allowed_durations: vec![5],
+            default_aspect_ratio: Some(AspectRatioV2::Ratio16x9),
+            default_resolution: Some(ResolutionV2::R720p),
+            default_duration: Some(5),
+            is_available: true,
+            is_internal: false,
+            model_icon: Some("https://yral.com/img/yral/favicon.svg".to_string()),
+            ios_model_icon: Some("https://yral.com/img/yral/android-chrome-192x192.png".to_string()),
+            extra_info: HashMap::from([
+                ("architecture".to_string(), serde_json::json!("DiT")),
+                ("model_size".to_string(), serde_json::json!("19B distilled")),
+                ("inference_time".to_string(), serde_json::json!("~7 seconds (cached)")),
+                ("hosting".to_string(), serde_json::json!("Self-hosted H100")),
+            ]),
+        }
+    }
+}

--- a/videogen-common/src/models/mod.rs
+++ b/videogen-common/src/models/mod.rs
@@ -1,10 +1,12 @@
 pub mod inttest;
+pub mod ltx2;
 pub mod lumalabs;
 pub mod speech_to_video;
 pub mod talkinghead;
 pub mod wan2_5;
 
 pub use inttest::IntTestModel;
+pub use ltx2::Ltx2Model;
 pub use lumalabs::LumaLabsModel;
 pub use talkinghead::TalkingHeadModel;
 pub use wan2_5::{Wan25FastModel, Wan25Model};

--- a/videogen-common/src/models/speech_to_video.rs
+++ b/videogen-common/src/models/speech_to_video.rs
@@ -80,7 +80,9 @@ impl SpeechToVideoModel {
         crate::types_v2::ProviderInfo {
             id: "speech_to_video".to_string(),
             name: "SpeechToVideo".to_string(),
-            description: "Generates videos from speech and optional image input using advanced AI models.".to_string(),
+            description:
+                "Generates videos from speech and optional image input using advanced AI models."
+                    .to_string(),
             supports_image: true,
             model_icon: Some("https://yral.com/img/yral/favicon.svg".to_string()),
             is_available: true,

--- a/videogen-common/src/token_costs.rs
+++ b/videogen-common/src/token_costs.rs
@@ -1,5 +1,7 @@
 use crate::TokenType;
-use global_constants::{VIDEOGEN_USD_CENTS_TO_DOLR_E8S, VIDEOGEN_USD_CENTS_TO_SATS};
+use global_constants::{
+    LTX2_COST_USD_CENTS, VIDEOGEN_USD_CENTS_TO_DOLR_E8S, VIDEOGEN_USD_CENTS_TO_SATS,
+};
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -50,7 +52,13 @@ impl Default for TokenCostConfig {
     fn default() -> Self {
         // NOTE: Model costs are now fetched dynamically via API
         // This provides default costs as a fallback
-        let model_costs_usd = HashMap::new();
+        let mut model_costs_usd = HashMap::new();
+        model_costs_usd.insert(
+            "ltx2".to_string(),
+            ModelCostUSD {
+                usd_cents: LTX2_COST_USD_CENTS,
+            },
+        );
 
         // Default cost for models not in the list
         let default_cost = ModelCostUSD::default();

--- a/videogen-common/src/types.rs
+++ b/videogen-common/src/types.rs
@@ -1,5 +1,5 @@
 use crate::models::{
-    speech_to_video::SpeechToVideoModel, IntTestModel, LumaLabsModel, TalkingHeadModel,
+    speech_to_video::SpeechToVideoModel, IntTestModel, Ltx2Model, LumaLabsModel, TalkingHeadModel,
     Wan25FastModel, Wan25Model,
 };
 // VideoModel has been removed - using ProviderInfo from types_v2 instead
@@ -87,6 +87,7 @@ pub enum VideoGenInput {
     Wan25(Wan25Model),
     Wan25Fast(Wan25FastModel),
     SpeechToVideo(SpeechToVideoModel),
+    Ltx2(Ltx2Model),
 }
 
 // VideoGenInput now gets model_name() and other methods from VideoGenerator trait via enum_dispatch
@@ -101,6 +102,7 @@ pub enum VideoGenProvider {
     Wan25,
     Wan25Fast,
     SpeechToVideo,
+    Ltx2,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, CandidType)]


### PR DESCRIPTION
- Add LTX2_COST_USD_CENTS constant to global-constants
- Create Ltx2Model in videogen-common with T2V, I2V, TI2V support
- Add Ltx2 variant to VideoGenInput and VideoGenProvider enums
- Register LTX2 in adapter registry for provider discovery

Self-hosted LTX-2 19B distilled model on Vast.ai H100. Supports text-to-video and image-to-video generation.