### PR TITLE
Change yral-metadata dependencies to 'main' branch

### DIFF
--- a/canisters-common/Cargo.toml
+++ b/canisters-common/Cargo.toml
@@ -16,8 +16,8 @@ identity = { workspace = true, default-features = false, features = [
 username-gen.workspace = true
 global-constants.workspace = true
 
-yral-metadata-client = { git = "https://github.com/yral-dapp/yral-metadata", branch = "master", default-features = false }
-yral-metadata-types = { git = "https://github.com/yral-dapp/yral-metadata", branch = "master", default-features = false }
+yral-metadata-client = { git = "https://github.com/yral-dapp/yral-metadata", branch = "main", default-features = false }
+yral-metadata-types = { git = "https://github.com/yral-dapp/yral-metadata", branch = "main", default-features = false }
 
 types.workspace = true
 sns-validation.path = "../sns-validation"


### PR DESCRIPTION
Updated yral-metadata dependencies to use 'main' branch.